### PR TITLE
Free self->matches which was missing (and leaked a ton of memory)

### DIFF
--- a/smatch/smatch.c
+++ b/smatch/smatch.c
@@ -211,6 +211,7 @@ PySMatchCat_dealloc(struct PySMatchCat* self)
     vector_free(self->pts);
     self->hpix = hpix_delete(self->hpix);
     self->tree = tree_delete(self->tree);
+    vector_free(self->matches);
 
 #if PY_MAJOR_VERSION >= 3
     Py_TYPE(self)->tp_free((PyObject*)self);


### PR DESCRIPTION
Note that this bug did not manifest itself in file output mode.  This doesn't change the peak memory usage (which was the same in file or non-file mode) but reduces the post-run memory by a factor of x3, and as an added bonus doesn't hold onto that memory forever.