### PR TITLE
Fix bug where len(ra) = 1 and len(radius) = 1

### DIFF
--- a/smatch/smatch.c
+++ b/smatch/smatch.c
@@ -90,10 +90,6 @@ static point_vector* points_init(PyObject* raObj, PyObject* decObj, PyObject* ra
 
     vector_resize(pts, n); 
 
-    if (nrad == 1) {
-        radptr = PyArray_GETPTR1(radObj, 0);
-        pt->radius = (*radptr)*D2R;
-    }
     for (i=0; i<n; i++) {
 
         pt=&pts->data[i];
@@ -108,12 +104,9 @@ static point_vector* points_init(PyObject* raObj, PyObject* decObj, PyObject* ra
             goto _points_init_bail;
         }
 
-        if (nrad > 1) {
-            radptr = PyArray_GETPTR1(radObj, i);
-            pt->radius = (*radptr)*D2R;
-            pt->cos_radius = cos( pt->radius );
-        }
-
+        radptr = PyArray_GETPTR1(radObj, 0);
+        pt->radius = (*radptr)*D2R;
+        pt->cos_radius = cos( pt->radius );
     }
 
 _points_init_bail:

--- a/smatch/test.py
+++ b/smatch/test.py
@@ -7,7 +7,7 @@ import numpy
 
 
 from . import smatch
-from .smatch import Catalog, read_matches
+from .smatch import Catalog, read_matches, match
 
 def test():
     suite = unittest.TestLoader().loadTestsFromTestCase(TestSMatch)
@@ -42,6 +42,12 @@ class TestSMatch(unittest.TestCase):
         self.assertEqual(nside, self.nside, "checking depth can be gotten")
 
         area=cat.get_hpix_area()
+
+    def testMatchArraysWithScalarRadius(self):
+        match(numpy.array([200, 200]), numpy.array([15, 15]), self.two, self.ra1, self.dec1)
+
+    def testMatchScalarsWithScalarRadius(self):
+        match(200, 15, self.two, self.ra1, self.dec1) # segfaults
 
     def testMatch(self):
 


### PR DESCRIPTION
If you checkout HEAD~1 (so just adding the tests) you should see a segfault on `testMatchScalarsWithScalarRadius`. This appears to be coming from the null `pt` https://github.com/esheldon/smatch/blob/55db16d214cf43f38ace2d924a4f6ec93c78ca4b/smatch/smatch.c#L95. I'm reasonably sure that the function sig in this test should be allowed (and even if not allowed should python error rather than segfault).

The change in the second commit fixes this (though as I mention, probably not in a particularly good way).

If I haven't misunderstood something and this should be fixed, I'm happy to dig deeper to understand this properly and fix properly. I just wanted to make sure that I wasn't completely wrong before doing that work :)