### PR TITLE
Change default to balanced tree, and add interface.

### DIFF
--- a/smatch/matcher.py
+++ b/smatch/matcher.py
@@ -91,18 +91,19 @@ class Matcher(object):
         The longitude in degrees.
     lat : array-like
         The latitude in degrees.
+    balanced : `bool`, optional
+        Should the underlying tree be balanced?
     """
-    def __init__(self, lon, lat):
+    def __init__(self, lon, lat, balanced=True):
         self.lon = np.atleast_1d(lon)
         self.lat = np.atleast_1d(lat)
+        self._balanced = balanced
 
     @property
     def tree(self):
         if not hasattr(self, "_tree"):
             coords = _lonlat2vec(self.lon, self.lat)
-            # The tree in the match does not need to be balanced, and
-            # turning this off yields significantly faster runtime.
-            self._tree = cKDTree(coords, compact_nodes=False, balanced_tree=False)
+            self._tree = cKDTree(coords, compact_nodes=False, balanced_tree=self._balanced)
         return self._tree
 
     def query_knn(
@@ -210,9 +211,7 @@ class Matcher(object):
             Returned if return_indices is True.
         """
         coords = _lonlat2vec(lon, lat)
-        # The second tree in the match does not need to be balanced, and
-        # turning this off yields significantly faster runtime.
-        qtree = cKDTree(coords, compact_nodes=False, balanced_tree=False)
+        qtree = cKDTree(coords, compact_nodes=False, balanced_tree=self._balanced)
         angle = 2.0*np.sin(np.deg2rad(radius)/2.0)
         idx = self.tree.query_ball_tree(qtree, angle, eps=eps)
 

--- a/smatch/tests/test_matcher.py
+++ b/smatch/tests/test_matcher.py
@@ -301,6 +301,26 @@ def test_matcher_context():
     assert hasattr(mch, "_tree")
 
 
+def test_matcher_context_unbalanced():
+    ra, dec = _gen_sphere_pts(50, 4543)
+    mch = Matcher(ra, dec, balanced=False)
+    assert not hasattr(mch, "_tree")
+    rap, decp = _gen_sphere_pts(100, 454)
+    mch.query_radius(rap, decp, 6e4/3600)
+    assert hasattr(mch, "_tree")
+
+    with Matcher(ra, dec, balanced=False) as mch:
+        rap, decp = _gen_sphere_pts(100, 454)
+        mch.query_radius(rap, decp, 6e4/3600)
+        assert hasattr(mch, "_tree")
+
+    assert not hasattr(mch, "_tree")
+
+    rap, decp = _gen_sphere_pts(100, 454)
+    mch.query_radius(rap, decp, 6e4/3600)
+    assert hasattr(mch, "_tree")
+
+
 def test_match_group_radius():
     ra, dec = _gen_sphere_pts(50, 4543)
     mch = Matcher(ra, dec)


### PR DESCRIPTION
Around scipy 1.8 they changed to a recursive algorithm for building the unbalanced tree, and this can fail catastrophically (seg-fault) in some cases on some operating systems.

There have also been other fixes to the balanced tree cases.

Since the balanced tree is the default, this PR changes the default to use the balanced tree to avoid these seg faults.  I will also do further performance investigations, and further checks of scipy to make appropriate recommendations there.