### PR TITLE
Add checks for nans in input arrays.

### DIFF
--- a/smatch/matcher.py
+++ b/smatch/matcher.py
@@ -94,7 +94,7 @@ class Matcher(object):
     balanced : `bool`, optional
         Should the underlying tree be balanced?
     """
-    def __init__(self, lon, lat, balanced=True):
+    def __init__(self, lon, lat, balanced=False):
         self.lon = np.atleast_1d(lon)
         self.lat = np.atleast_1d(lat)
         self._balanced = balanced

--- a/smatch/matcher.py
+++ b/smatch/matcher.py
@@ -99,6 +99,9 @@ class Matcher(object):
         self.lat = np.atleast_1d(lat)
         self._balanced = balanced
 
+        if np.any(np.isnan(self.lon) | np.isnan(self.lat)):
+            raise ValueError("At least one NaN found in lon/lat.")
+
     @property
     def tree(self):
         if not hasattr(self, "_tree"):
@@ -151,6 +154,9 @@ class Matcher(object):
             of dimension `k` added to the end. If `k=1`, then this last dimension
             is squeezed out.
         """
+        if np.any(np.isnan(lon) | np.isnan(lat)):
+            raise ValueError("At least one NaN found in lon/lat.")
+
         if distance_upper_bound is not None:
             maxd = 2*np.sin(np.deg2rad(distance_upper_bound)/2.)
         else:
@@ -210,6 +216,9 @@ class Matcher(object):
             Array of distance (degrees) for each match pair.
             Returned if return_indices is True.
         """
+        if np.any(np.isnan(lon) | np.isnan(lat)):
+            raise ValueError("At least one NaN found in lon/lat.")
+
         coords = _lonlat2vec(lon, lat)
         qtree = cKDTree(coords, compact_nodes=False, balanced_tree=self._balanced)
         angle = 2.0*np.sin(np.deg2rad(radius)/2.0)

--- a/smatch/tests/test_matcher.py
+++ b/smatch/tests/test_matcher.py
@@ -105,6 +105,16 @@ def test_matcher_knn_maxrad_inf(k):
     assert np.all(idx == 50)
 
 
+def test_matcher_knn_nan():
+    ra, dec = _gen_sphere_pts(50, 4543)
+    mch = Matcher(ra, dec)
+    rap, decp = _gen_sphere_pts(50, 443)
+    rap[0] = np.nan
+    with pytest.raises(ValueError):
+        idx, d = mch.query_knn(
+            rap, decp, distance_upper_bound=1/3600, k=1, return_distances=True)
+
+
 def test_matcher_radius():
     ra, dec = _gen_sphere_pts(50, 4543)
     mch = Matcher(ra, dec)
@@ -160,6 +170,18 @@ def test_match_radius_indices_nomatch():
     assert len(i1) == 0
     assert len(i2) == 0
     assert len(d) == 0
+
+
+def test_match_radius_nan():
+    ra = np.arange(10, dtype=np.float64)
+    dec = np.arange(10, dtype=np.float64)
+
+    mch = Matcher([30.0], [30.0])
+
+    dec[0] = np.nan
+
+    with pytest.raises(ValueError):
+        idx, i1, i2, d = mch.query_radius(ra, dec, 0.2, return_indices=True)
 
 
 def test_sphdist():
@@ -390,3 +412,11 @@ def test_match_group_radius_dupes():
         for ip in group:
             sep = sphdist(ra[ip], dec[ip], ra[group], dec[group])
             assert np.min(sep) < 6e4/3600.
+
+
+def test_matcher_nan():
+    ra, dec = _gen_sphere_pts(25, 4543)
+    dec[0] = np.nan
+
+    with pytest.raises(ValueError):
+        mch = Matcher(ra, dec)


### PR DESCRIPTION
This PR reverses the last PR decision to override the (faster) unbalanced tree.  Instead it does the correct thing and checks for nans and raises a ValueError if you try to build a tree out of NaNs.

Note that while scipy currently allows you to build a tree with nans instead of raising, this is likely to change in the future.

In general, I think it is reasonable to demand that the inputs not include nans.