### PR TITLE
Make smatch compatible with numpy 2

### DIFF
--- a/smatch/smatch.py
+++ b/smatch/smatch.py
@@ -25,7 +25,7 @@ def match(ra1, dec1, radius1, ra2, dec2,
         right ascension array 1 in degrees
     dec1: array
         declination array 1 in degrees, same size as ra1
-    radius: array or scalar
+    radius1: array or scalar
         search radius around each point in degrees; can be a scalar
         or same size as ra1/dec1.
 

--- a/smatch/smatch.py
+++ b/smatch/smatch.py
@@ -3,6 +3,12 @@ from sys import stderr
 import numpy as np
 from . import _smatch
 
+# Shim to support numpy >= 2 and < 2.0.0.
+if np.lib.NumpyVersion(np.__version__) >= "2.0.0":
+    copy_if_needed = None
+else:
+    copy_if_needed = False
+
 # area 0.013114 square degrees
 NSIDE_DEFAULT=4096
 
@@ -310,8 +316,8 @@ def read_matches(filename):
 
 
 def _get_arrays(ra, dec, radius=None):
-    ra=np.array(ra, ndmin=1, dtype='f8', copy=False)
-    dec=np.array(dec, ndmin=1, dtype='f8', copy=False)
+    ra=np.array(ra, ndmin=1, dtype='f8', copy=copy_if_needed)
+    dec=np.array(dec, ndmin=1, dtype='f8', copy=copy_if_needed)
 
     if ra.size != dec.size:
         mess="ra/dec size mismatch: %d %d"
@@ -319,7 +325,7 @@ def _get_arrays(ra, dec, radius=None):
 
     if radius is not None:
 
-        radarr=np.array(radius, ndmin=1, dtype='f8', copy=False)
+        radarr=np.array(radius, ndmin=1, dtype='f8', copy=copy_if_needed)
 
         if radarr.size != ra.size and radarr.size != 1:
             mess=("radius has size %d but expected either "


### PR DESCRIPTION
I'm back with another numpy 2 compatibility PR. I ran into this while working on something with Erin. This issue is not present when `Matcher` is used.